### PR TITLE
Added a slot-scoped gallery wrapper

### DIFF
--- a/src/components/gallery.vue
+++ b/src/components/gallery.vue
@@ -1,24 +1,26 @@
 <template>
   <section id="silentbox-gallery">
     <slot />
-    <div
-      v-for="(image, index) in galleryItems"
-      :key="image.src"
-      @click="openOverlay(image, index)"
-      class="silentbox-item"
-    >
-      <slot
-          name="silentbox-item"
-          v-bind:silentboxItem="image"
+    <slot name="gallery-wrapper" :galleryItems="galleryItems" :open-overlay="openOverlay">
+      <div
+        v-for="(image, index) in galleryItems"
+        :key="image.src"
+        @click="openOverlay(image, index)"
+        class="silentbox-item"
       >
-        <img
-          :src="image.thumbnail"
-          :alt="image.alt"
-          :width="image.thumbnailWidth"
-          :height="image.thumbnailHeight"
+        <slot
+            name="silentbox-item"
+            v-bind:silentboxItem="image"
         >
-      </slot>
-    </div>
+          <img
+            :src="image.thumbnail"
+            :alt="image.alt"
+            :width="image.thumbnailWidth"
+            :height="image.thumbnailHeight"
+          >
+        </slot>
+      </div>
+    </slot>
     <silentbox-overlay
       v-if="overlay.visible"
       :overlay-item="overlay.item"


### PR DESCRIPTION
Hey @silencesys, found your silentbox, great work!

I created this pull request for adding a slot-scoped wrapper around the gallery to have full power of customizing the gallery you want. At the moment you can change the view of single images, but not the wrapper around it.

With this pull request you could things like:

```
  <silent-box :gallery="images">
    <template v-slot:gallery-wrapper="{ galleryItems, openOverlay }">
      <div class="crazyWrapper">
        
        <custom-image 
            v-for="image in galleryImages"
            :key="image.src"
            class="someCrazyImageClass"
            @click="openOverlay"
        />

      </div>
    </template>
  </silent-box>
```