### PR TITLE
🐛 extra apostrophe

### DIFF
--- a/src/components/overlay.vue
+++ b/src/components/overlay.vue
@@ -18,7 +18,7 @@
             <!-- embed video rendering -->
             <iframe
               v-if="isEmbedVideo(overlayItem.src)"
-              :allow="`'accelerometer; ${ !!overlayItem.autoplay && 'autoplay;' } encrypted-media; gyroscope; picture-in-picture`"
+              :allow="`accelerometer; ${ !!overlayItem.autoplay && 'autoplay;' } encrypted-media; gyroscope; picture-in-picture`"
               :src="handleUrl(overlayItem.src)"
               frameborder="0"
               width="100%"


### PR DESCRIPTION
Sorry! I left an extra apostrophe when converting to an object literal.  Currently manifests as console warning `Unrecognized feature: ''accelerometer'.`

<img width="334" alt="Screen Shot 2021-02-26 at 12 32 18 AM" src="https://user-images.githubusercontent.com/4070380/109259522-5f3f1180-77ca-11eb-98a4-65b45b9aa0d2.png">